### PR TITLE
feat: Count tasks in each state

### DIFF
--- a/airflow_metrics/__init__.py
+++ b/airflow_metrics/__init__.py
@@ -1,7 +1,10 @@
-from airflow_metrics.airflow_metrics.patch_stats import patch_stats
 from airflow_metrics.utils.fn_utils import once
 
 
 @once
 def patch():
+    from airflow_metrics.airflow_metrics.patch_stats import patch_stats
     patch_stats()
+
+    from airflow_metrics.airflow_metrics.patch_tasks import patch_tasks
+    patch_tasks()

--- a/airflow_metrics/patch_tasks.py
+++ b/airflow_metrics/patch_tasks.py
@@ -1,0 +1,13 @@
+from airflow.models import TaskInstance
+from airflow_metrics.airflow_metrics.task_state import report_state
+from airflow_metrics.utils.event_utils import EventManager
+from airflow_metrics.utils.fn_utils import once
+
+
+@once
+def patch_tasks():
+    task_instance_after_insert_manager = EventManager(TaskInstance, 'after_insert')
+    task_instance_after_insert_manager.register_callback('state', report_state)
+
+    task_instance_after_update_manager = EventManager(TaskInstance, 'after_update')
+    task_instance_after_update_manager.register_callback('state', report_state)

--- a/airflow_metrics/task_state.py
+++ b/airflow_metrics/task_state.py
@@ -1,0 +1,10 @@
+from airflow.settings import Stats
+from sqlalchemy import inspect
+
+
+def report_state(target=None, new=None, old=None):
+    if new:  # can be None
+        Stats.incr('dag.task.state.{}'.format(new))
+
+    if old:  # can be None
+        Stats.decr('dag.task.state.{}'.format(old))

--- a/utils/event_utils.py
+++ b/utils/event_utils.py
@@ -1,0 +1,34 @@
+from airflow.utils.log.logging_mixin import LoggingMixin
+from collections import defaultdict
+from sqlalchemy import event, inspect
+
+
+class EventManager(LoggingMixin):
+    def __init__(self, cls, e):
+        self.cls = cls
+        self.e = e
+        self.callbacks = defaultdict(list)
+
+        @event.listens_for(self.cls, self.e)
+        def listener(mapper, conenction, target):
+            state = inspect(target)
+            for attr, callbacks in self.callbacks.items():
+                 history = state.get_history(attr, True)
+                 if not history.has_changes():
+                     continue
+
+                 for callback in callbacks:
+                     old = None
+                     if history.deleted and history.deleted[0]:
+                         old = history.deleted[0]  # not too clear on why this is a list
+
+                     new = None
+                     if history.added and history.added[0]:
+                         new = history.added[0]  # not too clear on why this is a list
+
+                     callback(target=target, new=new, old=old)
+
+
+    def register_callback(self, state, callback):
+        self.log.info('registering a callback')
+        self.callbacks[state].append(callback)


### PR DESCRIPTION
To indiciate the number of tasks in each state. For example, a high number of tasks being stuck
in the queued/scheduled state can indicate that the system is behaving abnormally.