### PR TITLE
feat: Report the state of all tasks

### DIFF
--- a/airflow_metrics/__init__.py
+++ b/airflow_metrics/__init__.py
@@ -8,3 +8,6 @@ def patch():
 
     from airflow_metrics.airflow_metrics.patch_tasks import patch_tasks
     patch_tasks()
+
+    from airflow_metrics.airflow_metrics.patch_thread import patch_thread
+    patch_thread()

--- a/airflow_metrics/patch_thread.py
+++ b/airflow_metrics/patch_thread.py
@@ -1,0 +1,29 @@
+from airflow.models import TaskInstance
+from airflow.settings import Stats
+from airflow.utils.db import provide_session
+from threading import Thread
+from time import sleep
+
+import sqlalchemy
+import sys
+
+
+@provide_session
+def report_states(session=None):
+    while True:
+        states = (
+            session.query(TaskInstance.state, sqlalchemy.func.count())
+            .group_by(TaskInstance.state)
+        )
+
+        for state, count in states:
+            Stats.gauge('dag.task.state.{}'.format(state), count)
+
+        sleep(10)
+
+
+def patch_thread():
+    if sys.argv[1] == 'webserver':
+        thread = Thread(target=report_states)
+        thread.start()
+        thread.join()


### PR DESCRIPTION
To indiciate the number of tasks in each state. For example, a high number of tasks being stuck
in the queued/scheduled state can indicate that the system is behaving abnormally