### PR TITLE
feat: Report the state and count of BigQueryOperators

### DIFF
--- a/airflow_metrics/patch_thread.py
+++ b/airflow_metrics/patch_thread.py
@@ -1,6 +1,8 @@
 from airflow.models import TaskInstance
 from airflow.settings import Stats
 from airflow.utils.db import provide_session
+from datetime import datetime, timedelta
+from pytz import utc
 from threading import Thread
 from time import sleep
 
@@ -9,21 +11,54 @@ import sys
 
 
 @provide_session
-def report_states(session=None):
-    while True:
-        states = (
-            session.query(TaskInstance.state, sqlalchemy.func.count())
-            .group_by(TaskInstance.state)
-        )
+def task_states(since, session=None):
+    states = (
+        session.query(TaskInstance.state, sqlalchemy.func.count())
+        .group_by(TaskInstance.state)
+    )
 
-        for state, count in states:
-            Stats.gauge('dag.task.state.{}'.format(state), count)
+    for state, count in states:
+        Stats.gauge('dag.task.state.{}'.format(state), count)
 
-        sleep(10)
+
+@provide_session
+def bq_task_states(since, session=None):
+    states = (
+        session.query(TaskInstance.state, sqlalchemy.func.count())
+        .filter(TaskInstance.operator=='BigQueryOperator')
+        .filter(TaskInstance.end_date>since)
+        .group_by(TaskInstance.state)
+    )
+
+    total = 0
+    for state, count in states:
+        if state is None:
+            continue
+
+        Stats.incr('dag.task.bq.state.{}'.format(state), count)
+        total += count
+
+    Stats.incr('dag.task.bq.count', total)
+
+
+def forever(fns, sleep_time):
+    passed = timedelta(seconds=sleep_time)
+
+    def fn():
+        while True:
+            for fn in fns:
+                since = datetime.utcnow() - passed
+                fn(utc.localize(since))
+            sleep(sleep_time)
+    return fn
 
 
 def patch_thread():
     if sys.argv[1] == 'webserver':
-        thread = Thread(target=report_states)
+        fns = [
+            task_states,
+            bq_task_states,
+        ]
+        thread = Thread(target=forever(fns, 10))
         thread.start()
         thread.join()


### PR DESCRIPTION
To Indicate the number of BigQueryOperators run and their results. For example, a high number
of BigQueryOperators in combination with a high number of failures may indicate that BigQuery
is behaving abnormally.