### PR TITLE
feat: Report final number of rows upserted by a BigQueryOperator

### DIFF
--- a/airflow_metrics/__init__.py
+++ b/airflow_metrics/__init__.py
@@ -11,3 +11,6 @@ def patch():
 
     from airflow_metrics.airflow_metrics.patch_thread import patch_thread
     patch_thread()
+
+    from airflow_metrics.airflow_metrics.patch_bq import patch_bq
+    patch_bq()

--- a/airflow_metrics/patch_bq.py
+++ b/airflow_metrics/patch_bq.py
@@ -1,0 +1,44 @@
+from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+from airflow.contrib.hooks.bigquery_hook import BigQueryCursor
+from airflow.settings import Stats
+from airflow_metrics.utils.hook_utils import HookManager
+
+
+def get_bq_job(ctx, self, *args, **kwargs):
+    bq_cursor = self.bq_cursor
+    service = bq_cursor.service
+    jobs = service.jobs()
+    job = jobs.get(projectId=bq_cursor.project_id,
+                   jobId=bq_cursor.running_job_id).execute()
+    ctx['job'] = job
+
+
+def bq_upserted(ctx, self, *args, **kwargs):
+    query_stats = ctx['job']['statistics']['query']['queryPlan']
+
+    all_queries = set()
+    upstream_queries = set()
+
+    for stat in query_stats:
+        all_queries.add(stat['id'])
+        upstream_queries.update(set(stat.get('inputStages', [])))
+
+    final_queries = all_queries - upstream_queries
+    written = 0
+
+    for stat in query_stats:
+        if stat['id'] not in final_queries:
+            continue
+
+        written += int(stat['recordsWritten'])
+
+    metric_id = 'dag.{}.{}.bq.upserted'.format(self.dag_id,
+                                               self.task_id)
+    Stats.gauge(metric_id, written)
+
+
+def patch_bq():
+    bq_operator_execute_manager = HookManager(BigQueryOperator, 'execute')
+    bq_operator_execute_manager.register_post_hook(get_bq_job)
+    bq_operator_execute_manager.register_post_hook(bq_upserted)
+    bq_operator_execute_manager.wrap_method(skip_on_fail=True)

--- a/utils/hook_utils.py
+++ b/utils/hook_utils.py
@@ -1,0 +1,68 @@
+from airflow.utils.log.logging_mixin import LoggingMixin
+from functools import wraps
+
+
+class HookException(Exception):
+    pass
+
+
+class HookTransaction(LoggingMixin):
+    def __init__(self,
+                 pre_hooks,
+                 post_hooks, skip_on_fail,
+                 *args, **kwargs):
+        self.pre_hooks = pre_hooks
+        self.post_hooks = post_hooks
+        self.skip_on_fail = skip_on_fail
+        self.args = args
+        self.kwargs = kwargs
+        self.context = {}
+
+    def __enter__(self):
+        self.log.info('Running pre-hooks')
+        for pre_hook in self.pre_hooks:
+            pre_hook(self.context, *self.args, **self.kwargs)
+
+    def __exit__(self, type, value, traceback):
+        if self.skip_on_fail and traceback:
+            # an error occured, skipping
+            self.log.warning('An error has occured, skipping the post-hooks')
+            return
+
+        self.log.info('Running post-hooks')
+        for post_hook in self.post_hooks:
+            post_hook(self.context, *self.args, **self.kwargs)
+
+
+class HookManager(LoggingMixin):
+    def __init__(self, cls, method_name):
+        self.cls = cls
+        self.method_name = method_name
+
+        self.pre_hooks = []
+        self.post_hooks = []
+
+    def wrap_method(self, skip_on_fail=False):
+        # TODO: check that this is a method?
+        method = getattr(self.cls, self.method_name)
+
+        @wraps(method)
+        def wrapped_method(*args, **kwargs):
+            with self.transaction(skip_on_fail, *args, **kwargs):
+                return method(*args, **kwargs)
+
+        setattr(self.cls, self.method_name, wrapped_method)
+
+    def transaction(self, skip_on_fail=False, *args, **kwargs):
+        return HookTransaction(self.pre_hooks,
+                               self.post_hooks,
+                               skip_on_fail,
+                               *args, **kwargs)
+
+    def register_pre_hook(self, pre_hook):
+        self.log.info('registering a pre-hook')
+        self.pre_hooks.append(pre_hook)
+
+    def register_post_hook(self, post_hook):
+        self.log.info('registering a post-hook')
+        self.post_hooks.append(post_hook)


### PR DESCRIPTION
To indicate the outcome of a BigQueryOperator. For example, if one run upserted less rows than
normal, it may indicate that the system is bahaving abnormally.