### PR TITLE
feat: Report time taken by GoogleCloudStorageToBigQueryOperator

### DIFF
--- a/airflow_metrics/__init__.py
+++ b/airflow_metrics/__init__.py
@@ -14,3 +14,6 @@ def patch():
 
     from airflow_metrics.airflow_metrics.patch_bq import patch_bq
     patch_bq()
+
+    from airflow_metrics.airflow_metrics.patch_gcs_2_bq import patch_gcs_2_bq
+    patch_gcs_2_bq()

--- a/airflow_metrics/patch_bq.py
+++ b/airflow_metrics/patch_bq.py
@@ -1,5 +1,4 @@
 from airflow.contrib.operators.bigquery_operator import BigQueryOperator
-from airflow.contrib.hooks.bigquery_hook import BigQueryCursor
 from airflow.settings import Stats
 from airflow_metrics.utils.hook_utils import HookManager
 

--- a/airflow_metrics/patch_gcs_2_bq.py
+++ b/airflow_metrics/patch_gcs_2_bq.py
@@ -1,0 +1,57 @@
+from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+from airflow.contrib.hooks.bigquery_hook import BigQueryConnection
+from airflow.settings import Stats
+from airflow_metrics.utils.hook_utils import HookManager
+
+import sys
+
+
+def attach_cursor(return_value, context, *args, **kwargs):
+    frame = sys._getframe(2)
+    local_vars = frame.f_locals
+    self = local_vars['self']
+    try:
+        if not isinstance(self, GoogleCloudStorageToBigQueryOperator):
+            # we only want to monkey patch gcs2bq
+            # make sure to pass the return value back
+            return return_value
+        self.__big_query_cursor__ = return_value
+        return return_value
+    finally:
+        del frame
+        del local_vars
+        del self
+
+
+def get_bq_job(ctx, self, *args, **kwargs):
+    bq_cursor = self.__big_query_cursor__
+    service = bq_cursor.service
+    jobs = service.jobs()
+    job = jobs.get(projectId=bq_cursor.project_id,
+                   jobId=bq_cursor.running_job_id).execute()
+    ctx['job'] = job
+
+
+def bq_duration(ctx, self, *args, **kwargs):
+    stats = ctx['job']['statistics']
+    creation = int(stats['creationTime'])
+    start = int(stats['startTime'])
+    end = int(stats['endTime'])
+
+    delay_metric = 'dag.{}.{}.gcs_to_bq.delay'.format(self.dag_id,
+                                               self.task_id)
+    duration_metric = 'dag.{}.{}.gcs_to_bq.duration'.format(self.dag_id,
+                                                     self.task_id)
+    Stats.timing(delay_metric, start - creation)
+    Stats.timing(duration_metric, end - start)
+
+
+def patch_gcs_2_bq():
+    bq_connection_cursor_manager = HookManager(BigQueryConnection, 'cursor')
+    bq_connection_cursor_manager.register_post_hook(attach_cursor)
+    bq_connection_cursor_manager.post_process()
+
+    gcs_to_bq_operator_execute_manager = HookManager(GoogleCloudStorageToBigQueryOperator, 'execute')
+    gcs_to_bq_operator_execute_manager.register_post_hook(get_bq_job)
+    gcs_to_bq_operator_execute_manager.register_post_hook(bq_duration)
+    gcs_to_bq_operator_execute_manager.wrap_method(skip_on_fail=True)

--- a/utils/hook_utils.py
+++ b/utils/hook_utils.py
@@ -42,6 +42,26 @@ class HookManager(LoggingMixin):
         self.pre_hooks = []
         self.post_hooks = []
 
+    def post_process(self):
+        if self.pre_hooks:
+            msg = 'post process only runs the post_hooks but {} pre_hook(s) found'
+            self.log.warn(msg.format(len(self.pre_hooks)))
+
+        # TODO: check that this is a method?
+        method = getattr(self.cls, self.method_name)
+
+        @wraps(method)
+        def wrapped_method(*args, **kwargs):
+            return_value = method(*args, **kwargs)
+
+            context = {}
+            for fn in self.post_hooks:
+                return_value = fn(return_value, context, *args, **kwargs)
+
+            return return_value
+
+        setattr(self.cls, self.method_name, wrapped_method)
+
     def wrap_method(self, skip_on_fail=False):
         # TODO: check that this is a method?
         method = getattr(self.cls, self.method_name)


### PR DESCRIPTION
To indicate the duration of a GoogleCloudStorageToBigQueryOperator. For example, if one run
takes longer/shorter than normal, it may indicate that the system is behaving abnormally.