### PR TITLE
fix: Move thread to the scheduler and do not wait

### DIFF
--- a/airflow_metrics/patch_thread.py
+++ b/airflow_metrics/patch_thread.py
@@ -54,11 +54,10 @@ def forever(fns, sleep_time):
 
 
 def patch_thread():
-    if sys.argv[1] == 'webserver':
+    if sys.argv[1] == 'scheduler':
         fns = [
             task_states,
             bq_task_states,
         ]
         thread = Thread(target=forever(fns, 10))
         thread.start()
-        thread.join()


### PR DESCRIPTION
Composer runs webserver through gunicorn and this naive approach fails. However we can run it
in the scheduler as there is only 1 instance and make sure not to wait for the thread which is
a blocking operation.