### PR TITLE
fix: Daemonize the metrics thread

### DIFF
--- a/airflow_metrics/patch_thread.py
+++ b/airflow_metrics/patch_thread.py
@@ -62,6 +62,7 @@ def patch_thread():
                 bq_task_states,
             ]
             thread = Thread(target=forever(fns, 10))
+            thread.daemon = True
             thread.start()
     except Exception as e:
         # if any of this throws an error, then we're not in any


### PR DESCRIPTION
If the main scheduler thread crashes, metrics thread should not prevent the process from exiting.