### PR TITLE
feat: Use Datadog's tag feature to aggregate metrics better

### DIFF
--- a/airflow_metrics/patch_bq.py
+++ b/airflow_metrics/patch_bq.py
@@ -31,9 +31,12 @@ def bq_upserted(ctx, self, *args, **kwargs):
 
         written += int(stat['recordsWritten'])
 
-    metric_id = 'dag.{}.{}.bq.upserted'.format(self.dag_id,
-                                               self.task_id)
-    Stats.gauge(metric_id, written)
+    tags = {
+        'dag': self.dag_id,
+        'task': self.task_id,
+        'operator': self.__class__.__name__,
+    }
+    Stats.gauge('task.upserted.bq', written, tags=tags)
 
 
 def bq_duration(ctx, self, *args, **kwargs):
@@ -42,13 +45,13 @@ def bq_duration(ctx, self, *args, **kwargs):
     start = int(stats['startTime'])
     end = int(stats['endTime'])
 
-    delay_metric = 'dag.{}.{}.bq.delay'.format(self.dag_id,
-                                               self.task_id)
-    duration_metric = 'dag.{}.{}.bq.duration'.format(self.dag_id,
-                                                     self.task_id)
-
-    Stats.timing(delay_metric, start - creation)
-    Stats.timing(duration_metric, end - start)
+    tags = {
+        'dag': self.dag_id,
+        'task': self.task_id,
+        'operator': self.__class__.__name__,
+    }
+    Stats.timing('task.delay.bq', start - creation, tags=tags)
+    Stats.timing('task.duration.bq', end - start, tags=tags)
 
 
 def patch_bq():

--- a/airflow_metrics/patch_gcs_2_bq.py
+++ b/airflow_metrics/patch_gcs_2_bq.py
@@ -38,19 +38,23 @@ def bq_duration(ctx, self, *args, **kwargs):
     start = int(stats['startTime'])
     end = int(stats['endTime'])
 
-    delay_metric = 'dag.{}.{}.gcs_to_bq.delay'.format(self.dag_id,
-                                               self.task_id)
-    duration_metric = 'dag.{}.{}.gcs_to_bq.duration'.format(self.dag_id,
-                                                     self.task_id)
-    Stats.timing(delay_metric, start - creation)
-    Stats.timing(duration_metric, end - start)
+    tags = {
+        'dag': self.dag_id,
+        'task': self.task_id,
+        'operator': self.__class__.__name__,
+    }
+    Stats.timing('task.delay.gcs_to_bq', start - creation, tags=tags)
+    Stats.timing('task.duration.gcs_to_bq', end - start, tags=tags)
 
 
 def rows_copied(ctx, self, *args, **kwargs):
     rows = ctx['job']['statistics']['load']['outputRows']
-    metric_id = 'dag.{}.{}.gcs_2_bq.copied'.format(self.dag_id,
-                                               self.task_id)
-    Stats.gauge(metric_id, rows)
+    tags = {
+        'dag': self.dag_id,
+        'task': self.task_id,
+        'operator': self.__class__.__name__,
+    }
+    Stats.gauge('task.upserted.gcs_to_bq', rows, tags=tags)
 
 
 def patch_gcs_2_bq():

--- a/airflow_metrics/patch_tasks.py
+++ b/airflow_metrics/patch_tasks.py
@@ -7,20 +7,22 @@ from airflow.settings import Stats
 
 def dag_duration(target=None, new=None, old=None):
     if target.start_date and target.end_date:
-        metric_id = 'dag.{}.{}.duration'.format(target.dag_id,
-                                                target.state)
         duration = (target.end_date - target.start_date).total_seconds()
-
-        Stats.timing(metric_id, duration * 1000)
+        tags = {
+            'dag': target.dag_id,
+        }
+        Stats.timing('dag.duration', duration * 1000, tags=tags)
 
 
 def task_duration(target=None, new=None, old=None):
     if target.duration:
-        metric_id = 'dag.{}.{}.{}.duration'.format(target.dag_id,
-                                                   target.task_id,
-                                                   target.state)
-
-        Stats.timing(metric_id, target.duration * 1000)
+        tags = {
+            'dag': target.dag_id,
+            'task': target.task_id,
+            'state': target.state,
+            'operator': target.operator,
+        }
+        Stats.timing('task.duration', target.duration * 1000, tags=tags)
 
 
 @once

--- a/airflow_metrics/patch_thread.py
+++ b/airflow_metrics/patch_thread.py
@@ -19,7 +19,11 @@ def task_states(since, session=None):
     )
 
     for state, count in states:
-        Stats.gauge('dag.task.state.{}'.format(state), count)
+        if state is None:
+            continue
+
+        tags = { 'state': state }
+        Stats.gauge('task.state', count, tags=tags)
 
 
 @provide_session
@@ -31,15 +35,12 @@ def bq_task_states(since, session=None):
         .group_by(TaskInstance.state)
     )
 
-    total = 0
     for state, count in states:
         if state is None:
             continue
 
-        Stats.incr('dag.task.bq.state.{}'.format(state), count)
-        total += count
-
-    Stats.incr('dag.task.bq.count', total)
+        tags = { 'state': state }
+        Stats.incr('task.state.bq', count, tags=tags)
 
 
 def forever(fns, sleep_time):


### PR DESCRIPTION
Using the tags feature allows there to be less unique metric names and simplifies the process of
creating a dashboard on Datadog since new graphs can be automatically created based on the tags.