### PR TITLE
Fix/scheduler stability

### DIFF
--- a/airflow_metrics/airflow_metrics/patch_bq.py
+++ b/airflow_metrics/airflow_metrics/patch_bq.py
@@ -1,4 +1,10 @@
-from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+try:
+    from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+except ModuleNotFoundError:
+    LoggingMixin().log.info("BigQuery not configured in Airflow. Skipping...")
+
 from airflow.settings import Stats
 
 from airflow_metrics.utils.fn_utils import once
@@ -10,58 +16,59 @@ def get_bq_job(ctx, self, *args, **kwargs):
     bq_cursor = self.bq_cursor
     service = bq_cursor.service
     jobs = service.jobs()
-    job = jobs.get(projectId=bq_cursor.project_id,
-                   jobId=bq_cursor.running_job_id).execute()
-    ctx['job'] = job
+    job = jobs.get(
+        projectId=bq_cursor.project_id, jobId=bq_cursor.running_job_id
+    ).execute()
+    ctx["job"] = job
 
 
 @HookManager.success_only
 def bq_upserted(ctx, self, *args, **kwargs):
-    query_stats = ctx['job']['statistics']['query']['queryPlan']
+    query_stats = ctx["job"]["statistics"]["query"]["queryPlan"]
 
     all_queries = set()
     upstream_queries = set()
 
     for stat in query_stats:
-        all_queries.add(stat['id'])
-        upstream_queries.update(set(stat.get('inputStages', [])))
+        all_queries.add(stat["id"])
+        upstream_queries.update(set(stat.get("inputStages", [])))
 
     final_queries = all_queries - upstream_queries
     written = 0
 
     for stat in query_stats:
-        if stat['id'] not in final_queries:
+        if stat["id"] not in final_queries:
             continue
 
-        written += int(stat['recordsWritten'])
+        written += int(stat["recordsWritten"])
 
     tags = {
-        'dag': self.dag_id,
-        'task': self.task_id,
-        'operator': self.__class__.__name__,
+        "dag": self.dag_id,
+        "task": self.task_id,
+        "operator": self.__class__.__name__,
     }
-    Stats.gauge('task.upserted.bq', written, tags=tags)
+    Stats.gauge("task.upserted.bq", written, tags=tags)
 
 
 @HookManager.success_only
 def bq_duration(ctx, self, *args, **kwargs):
-    stats = ctx['job']['statistics']
-    creation = int(stats['creationTime'])
-    start = int(stats['startTime'])
-    end = int(stats['endTime'])
+    stats = ctx["job"]["statistics"]
+    creation = int(stats["creationTime"])
+    start = int(stats["startTime"])
+    end = int(stats["endTime"])
 
     tags = {
-        'dag': self.dag_id,
-        'task': self.task_id,
-        'operator': self.__class__.__name__,
+        "dag": self.dag_id,
+        "task": self.task_id,
+        "operator": self.__class__.__name__,
     }
-    Stats.timing('task.delay.bq', start - creation, tags=tags)
-    Stats.timing('task.duration.bq', end - start, tags=tags)
+    Stats.timing("task.delay.bq", start - creation, tags=tags)
+    Stats.timing("task.duration.bq", end - start, tags=tags)
 
 
 @once
 def patch_bq():
-    bq_operator_execute_manager = HookManager(BigQueryOperator, 'execute')
+    bq_operator_execute_manager = HookManager(BigQueryOperator, "execute")
     bq_operator_execute_manager.register_post_hook(get_bq_job)
     bq_operator_execute_manager.register_post_hook(bq_upserted)
     bq_operator_execute_manager.register_post_hook(bq_duration)

--- a/airflow_metrics/airflow_metrics/patch_bq.py
+++ b/airflow_metrics/airflow_metrics/patch_bq.py
@@ -1,7 +1,7 @@
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 try:
-    from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+    from airflow.operators.bigquery_operator import BigQueryOperator
 except ModuleNotFoundError:
     LoggingMixin().log.info("BigQuery not configured in Airflow. Skipping...")
 

--- a/airflow_metrics/airflow_metrics/patch_gcs_2_bq.py
+++ b/airflow_metrics/airflow_metrics/patch_gcs_2_bq.py
@@ -1,8 +1,8 @@
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 try:
-    from airflow.contrib.hooks.bigquery_hook import BigQueryConnection
-    from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+    from airflow.hooks.bigquery_hook import BigQueryConnection
+    from airflow.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
 except ModuleNotFoundError:
     LoggingMixin().log.info(
         "Google Cloud Provider not configured in Airflow. Skipping..."

--- a/airflow_metrics/airflow_metrics/patch_gcs_2_bq.py
+++ b/airflow_metrics/airflow_metrics/patch_gcs_2_bq.py
@@ -1,7 +1,14 @@
-from functools import wraps
+from airflow.utils.log.logging_mixin import LoggingMixin
 
-from airflow.contrib.hooks.bigquery_hook import BigQueryConnection
-from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+try:
+    from airflow.contrib.hooks.bigquery_hook import BigQueryConnection
+    from airflow.contrib.operators.gcs_to_bq import GoogleCloudStorageToBigQueryOperator
+except ModuleNotFoundError:
+    LoggingMixin().log.info(
+        "Google Cloud Provider not configured in Airflow. Skipping..."
+    )
+
+from functools import wraps
 from airflow.settings import Stats
 
 from airflow_metrics.utils.fn_utils import get_calling_operator
@@ -13,15 +20,16 @@ from airflow_metrics.utils.hook_utils import HookManager
 def attach_cursor(ctx, *args, **kwargs):
     operator = get_calling_operator()
     if isinstance(operator, GoogleCloudStorageToBigQueryOperator):
-        operator.__big_query_cursor__ = ctx['return']
+        operator.__big_query_cursor__ = ctx["return"]
 
 
 def has_cursor(func):
     @wraps(func)
     def wrapped(ctx, self, *args, **kwargs):
-        if not hasattr(self, '__big_query_cursor__'):
+        if not hasattr(self, "__big_query_cursor__"):
             return None
         return func(ctx, self, *args, **kwargs)
+
     return wrapped
 
 
@@ -31,48 +39,50 @@ def get_bq_job(ctx, self, *args, **kwargs):
     bq_cursor = self.__big_query_cursor__
     service = bq_cursor.service
     jobs = service.jobs()
-    job = jobs.get(projectId=bq_cursor.project_id,
-                   jobId=bq_cursor.running_job_id).execute()
-    ctx['job'] = job
+    job = jobs.get(
+        projectId=bq_cursor.project_id, jobId=bq_cursor.running_job_id
+    ).execute()
+    ctx["job"] = job
 
 
 @HookManager.success_only
 @has_cursor
 def bq_upserted(ctx, self, *args, **kwargs):
-    rows = ctx['job']['statistics']['load']['outputRows']
+    rows = ctx["job"]["statistics"]["load"]["outputRows"]
     tags = {
-        'dag': self.dag_id,
-        'task': self.task_id,
-        'operator': self.__class__.__name__,
+        "dag": self.dag_id,
+        "task": self.task_id,
+        "operator": self.__class__.__name__,
     }
-    Stats.gauge('task.upserted.gcs_to_bq', rows, tags=tags)
+    Stats.gauge("task.upserted.gcs_to_bq", rows, tags=tags)
 
 
 @HookManager.success_only
 @has_cursor
 def bq_duration(ctx, self, *args, **kwargs):
-    stats = ctx['job']['statistics']
-    creation = int(stats['creationTime'])
-    start = int(stats['startTime'])
-    end = int(stats['endTime'])
+    stats = ctx["job"]["statistics"]
+    creation = int(stats["creationTime"])
+    start = int(stats["startTime"])
+    end = int(stats["endTime"])
 
     tags = {
-        'dag': self.dag_id,
-        'task': self.task_id,
-        'operator': self.__class__.__name__,
+        "dag": self.dag_id,
+        "task": self.task_id,
+        "operator": self.__class__.__name__,
     }
-    Stats.timing('task.delay.gcs_to_bq', start - creation, tags=tags)
-    Stats.timing('task.duration.gcs_to_bq', end - start, tags=tags)
+    Stats.timing("task.delay.gcs_to_bq", start - creation, tags=tags)
+    Stats.timing("task.duration.gcs_to_bq", end - start, tags=tags)
 
 
 @once
 def patch_gcs_2_bq():
-    bq_connection_cursor_manager = HookManager(BigQueryConnection, 'cursor')
+    bq_connection_cursor_manager = HookManager(BigQueryConnection, "cursor")
     bq_connection_cursor_manager.register_post_hook(attach_cursor)
     bq_connection_cursor_manager.wrap_method()
 
-    gcs_to_bq_operator_execute_manager = \
-            HookManager(GoogleCloudStorageToBigQueryOperator, 'execute')
+    gcs_to_bq_operator_execute_manager = HookManager(
+        GoogleCloudStorageToBigQueryOperator, "execute"
+    )
     gcs_to_bq_operator_execute_manager.register_post_hook(get_bq_job)
     gcs_to_bq_operator_execute_manager.register_post_hook(bq_upserted)
     gcs_to_bq_operator_execute_manager.register_post_hook(bq_duration)


### PR DESCRIPTION
This PR bring `airflow-metrics` into alignment with airflow 1.10.5, with the following changes:
- enables configuration of individual metrics via environmental variables (follows the airflow style for [setting configuration options](https://airflow.apache.org/howto/set-config.html?highlight=double%20underscore#setting-configuration-options)
- uses conditional import statements for gcp and bq to avoid `ModuleNotFoundError` errors in log/sentry
- uses core operators and hooks for gcp and bq instead of deprecated (beta) ones

Other changes formatting and linting changes to meet internal styleguide.