### PR TITLE
Reduce log level of blacklisted domains from WARNING to INFO

### DIFF
--- a/airflow_metrics/airflow_metrics/patch_requests.py
+++ b/airflow_metrics/airflow_metrics/patch_requests.py
@@ -24,7 +24,7 @@ def attach_request_meta(ctx, *args, **kwargs):
         request = args[1]
         url = request.url
     else:
-        LOG.warning('No url found for request')
+        LOG.info('No url found for request')
         return
     ctx['url'] = url
 


### PR DESCRIPTION
Reduces the log level for the message "Found blacklisted domain" in `patch_requests.py` from `WARNING` to `INFO` because each warning log sends a message to Sentry. For my team, this becomes over 17,000 warnings every day, which is excessive for this warning that is largely unactionable.