### PR TITLE
Fix log level change of blacklisted domain messages from WARNING to INFO

### DIFF
--- a/airflow_metrics/airflow_metrics/patch_requests.py
+++ b/airflow_metrics/airflow_metrics/patch_requests.py
@@ -24,7 +24,7 @@ def attach_request_meta(ctx, *args, **kwargs):
         request = args[1]
         url = request.url
     else:
-        LOG.info('No url found for request')
+        LOG.warning('No url found for request')
         return
     ctx['url'] = url
 


### PR DESCRIPTION
Reverts getsentry/airflow-metrics#49, in which I accidentally changed the log level of the wrong log message. Pardon please pardon my mistake.

This PR includes the correct change, which applies the same change articulated in #49: Reduces the log level for the message "Found blacklisted domain" in `patch_requests.py` from `WARNING` to `INFO` because each warning log sends a message to Sentry. For my team, this becomes over 17,000 warnings every day, which is excessive for this warning that is largely unactionable.