### PR TITLE
Reduce log level of blacklisted domains from WARNING to INFO

### DIFF
--- a/airflow_metrics/airflow_metrics/patch_requests.py
+++ b/airflow_metrics/airflow_metrics/patch_requests.py
@@ -30,7 +30,7 @@ def attach_request_meta(ctx, *args, **kwargs):
 
     domain = urlparse(url).netloc
     if domain in BLACKLIST:
-        LOG.warning('Found blacklisted domain: {}'.format(domain))
+        LOG.info('Found blacklisted domain: {}'.format(domain))
         return
     ctx['domain'] = domain
 


### PR DESCRIPTION
Fixes #49, in which I accidentally reduced the log level of the wrong message.

This commit reduces the log level for the message "Found blacklisted domain" in `patch_requests.py` from `WARNING` to `INFO` because each warning log sends a message to Sentry. For my team, this becomes over 17,000 warnings every day, which is excessive for this warning that is largely unactionable.